### PR TITLE
Use filesets to match assemblies to test, relativize paths exposed to environment variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.466</version>
+    <version>1.554.3</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -21,9 +21,11 @@ import hudson.tasks.Builder;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.util.ArgumentListBuilder;
+import java.io.File;
 import java.nio.file.Paths;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.tools.ant.types.FileSet;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -32,36 +34,55 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class VsTestBuilder extends Builder {
 
-    /** Platform:x86 */
+    /**
+     * Platform:x86
+     */
     private static final String PLATFORM_X86 = "x86";
 
-    /** Platform:x64 */
+    /**
+     * Platform:x64
+     */
     private static final String PLATFORM_X64 = "x64";
 
-    /** Platform:ARM */
+    /**
+     * Platform:ARM
+     */
     private static final String PLATFORM_ARM = "ARM";
 
-    /** Platform:Other */
+    /**
+     * Platform:Other
+     */
     private static final String PLATFORM_OTHER = "Other";
 
-    /** .NET Framework 3.5 */
+    /**
+     * .NET Framework 3.5
+     */
     private static final String FRAMEWORK_35 = "framework35";
 
-    /** .NET Framework 4.0 */
+    /**
+     * .NET Framework 4.0
+     */
     private static final String FRAMEWORK_40 = "framework40";
 
-    /** .NET Framework 4.5 */
+    /**
+     * .NET Framework 4.5
+     */
     private static final String FRAMEWORK_45 = "framework45";
 
-    /** .NET Framework Other */
+    /**
+     * .NET Framework Other
+     */
     private static final String FRAMEWORK_OTHER = "Other";
 
-    /** Logger TRX */
+    /**
+     * Logger TRX
+     */
     private static final String LOGGER_TRX = "trx";
 
-    /** Logger Other */
+    /**
+     * Logger Other
+     */
     private static final String LOGGER_OTHER = "Other";
-
 
     private final String vsTestName;
     private final String testFiles;
@@ -100,26 +121,23 @@ public class VsTestBuilder extends Builder {
      * @param failBuild
      */
     @DataBoundConstructor
-    public VsTestBuilder(String vsTestName, String testFiles, String settings, String tests, String testCaseFilter
-                        ,boolean enablecodecoverage, boolean inIsolation, boolean useVsixExtensions, String platform, String otherPlatform
-                        ,String framework, String otherFramework, String logger, String otherLogger
-                        ,String cmdLineArgs, boolean failBuild) {
-        this.vsTestName         = vsTestName;
-        this.testFiles          = testFiles;
-        this.settings           = settings;
-        this.tests              = tests;
-        this.testCaseFilter     = testCaseFilter;
+    public VsTestBuilder(String vsTestName, String testFiles, String settings, String tests, String testCaseFilter, boolean enablecodecoverage, boolean inIsolation, boolean useVsixExtensions, String platform, String otherPlatform, String framework, String otherFramework, String logger, String otherLogger, String cmdLineArgs, boolean failBuild) {
+        this.vsTestName = vsTestName;
+        this.testFiles = testFiles;
+        this.settings = settings;
+        this.tests = tests;
+        this.testCaseFilter = testCaseFilter;
         this.enablecodecoverage = enablecodecoverage;
-        this.inIsolation        = inIsolation;
-        this.useVsixExtensions  = useVsixExtensions;
-        this.platform           = platform;
-        this.otherPlatform      = PLATFORM_OTHER.equals(this.platform) ? otherPlatform : "";
-        this.framework          = framework;
-        this.otherFramework     = FRAMEWORK_OTHER.equals(this.framework) ? otherFramework : "";
-        this.logger             = logger;
-        this.otherLogger        = LOGGER_OTHER.equals(this.logger) ? otherLogger : "";
-        this.cmdLineArgs        = cmdLineArgs;
-        this.failBuild          = failBuild;
+        this.inIsolation = inIsolation;
+        this.useVsixExtensions = useVsixExtensions;
+        this.platform = platform;
+        this.otherPlatform = PLATFORM_OTHER.equals(this.platform) ? otherPlatform : "";
+        this.framework = framework;
+        this.otherFramework = FRAMEWORK_OTHER.equals(this.framework) ? otherFramework : "";
+        this.logger = logger;
+        this.otherLogger = LOGGER_OTHER.equals(this.logger) ? otherLogger : "";
+        this.cmdLineArgs = cmdLineArgs;
+        this.failBuild = failBuild;
     }
 
     public String getVsTestName() {
@@ -197,7 +215,7 @@ public class VsTestBuilder extends Builder {
 
     @Override
     public DescriptorImpl getDescriptor() {
-         return DESCRIPTOR;
+        return DESCRIPTOR;
     }
 
     /**
@@ -219,7 +237,7 @@ public class VsTestBuilder extends Builder {
             super(VsTestBuilder.class);
             load();
         }
-        
+
         public boolean isApplicable(final Class<? extends AbstractProject> aClass) {
             return true;
         }
@@ -256,57 +274,70 @@ public class VsTestBuilder extends Builder {
 
         // VsTest.console.exe path.
         String pathToVsTest = getVsTestPath(launcher, listener, env);
-        if (pathToVsTest == null) return false;
+        if (pathToVsTest == null) {
+            return false;
+        }
         args.add(pathToVsTest);
 
-        // Tareget dll path
-        if (!StringUtils.isBlank(testFiles))
+        // Target dll path
+        if (!StringUtils.isBlank(testFiles)) {
             args.addAll(getTestFilesArguments(build, env));
+        }
 
         // Run tests with additional settings such as data collectors.
-        if (!StringUtils.isBlank(settings))
+        if (!StringUtils.isBlank(settings)) {
             args.add(convertArgumentWithQuote("Settings", replaceMacro(settings, env, build)));
+        }
 
         // Run tests with names that match the provided values.
-        if (!StringUtils.isBlank(tests))
+        if (!StringUtils.isBlank(tests)) {
             args.add(convertArgument("Tests", replaceMacro(tests, env, build)));
+        }
 
         // Run tests that match the given expression.
-        if (!StringUtils.isBlank(testCaseFilter))
+        if (!StringUtils.isBlank(testCaseFilter)) {
             args.add(convertArgumentWithQuote("TestCaseFilter", replaceMacro(testCaseFilter, env, build)));
+        }
 
         // Enables data diagnostic adapter CodeCoverage in the test run.
-        if (enablecodecoverage)
+        if (enablecodecoverage) {
             args.add("/Enablecodecoverage");
+        }
 
         // Runs the tests in an isolated process.
-        if (inIsolation)
+        if (inIsolation) {
             args.add("/InIsolation");
+        }
 
         // This makes vstest.console.exe process use or skip the VSIX extensions installed (if any) in the test run.
-        if (useVsixExtensions)
+        if (useVsixExtensions) {
             args.add("/UseVsixExtensions:true");
-        else
+        } else {
             args.add("/UseVsixExtensions:false");
+        }
 
         // Target platform architecture to be used for test execution.
         String platformArg = getPlatformArgument(env, build);
-        if (!StringUtils.isBlank(platformArg))
+        if (!StringUtils.isBlank(platformArg)) {
             args.add(convertArgument("Platform", platformArg));
+        }
 
         // Target .NET Framework version to be used for test execution.
         String frameworkArg = getFrameworkArgument(env, build);
-        if (!StringUtils.isBlank(frameworkArg))
+        if (!StringUtils.isBlank(frameworkArg)) {
             args.add(convertArgument("Framework", frameworkArg));
+        }
 
         // Specify a logger for test results.
         String loggerArg = getLoggerArgument(env, build);
-        if (!StringUtils.isBlank(loggerArg))
+        if (!StringUtils.isBlank(loggerArg)) {
             args.add(convertArgument("Logger", loggerArg));
+        }
 
         // Manual Command Line String
-        if (!StringUtils.isBlank(cmdLineArgs))
+        if (!StringUtils.isBlank(cmdLineArgs)) {
             args.add(replaceMacro(cmdLineArgs, env, build));
+        }
 
         // VSTest run.
         boolean r = execVsTest(args, build, launcher, listener, env);
@@ -365,7 +396,6 @@ public class VsTestBuilder extends Builder {
         }
     }
 
-
     /**
      *
      * @param build
@@ -384,11 +414,30 @@ public class VsTestBuilder extends Builder {
             testFile = replaceMacro(testFile, env, build);
 
             if (!StringUtils.isBlank(testFile)) {
-                args.add(appendQuote(testFile));
+
+                for (String file : expandFileSet(build, testFile)) {
+                    args.add(appendQuote(testFile));
+                }
             }
         }
 
         return args;
+    }
+
+    private String[] expandFileSet(AbstractBuild<?, ?> build, String pattern) {
+        String[] result =  new String[] { pattern };
+        FileSet fileSet = new FileSet();
+        org.apache.tools.ant.Project project = new org.apache.tools.ant.Project();
+        fileSet.setProject(project);
+        try {
+        fileSet.setDir(new File(build.getWorkspace().toURI().getPath()));
+        fileSet.setIncludes(pattern);
+        } catch (IOException ioe) {
+            return result;
+        } catch (InterruptedException intE) {
+            return result;
+        }
+        return fileSet.getDirectoryScanner(project).getIncludedFiles();
     }
 
     /**
@@ -398,12 +447,13 @@ public class VsTestBuilder extends Builder {
      * @return
      */
     private String getPlatformArgument(EnvVars env, AbstractBuild<?, ?> build) {
-        if (PLATFORM_X86.equals(platform) || PLATFORM_X64.equals(platform) || PLATFORM_ARM.equals(platform))
+        if (PLATFORM_X86.equals(platform) || PLATFORM_X64.equals(platform) || PLATFORM_ARM.equals(platform)) {
             return platform;
-        else if (PLATFORM_OTHER.equals(platform))
+        } else if (PLATFORM_OTHER.equals(platform)) {
             return replaceMacro(otherPlatform, env, build);
-        else
+        } else {
             return null;
+        }
     }
 
     /**
@@ -413,12 +463,13 @@ public class VsTestBuilder extends Builder {
      * @return
      */
     private String getFrameworkArgument(EnvVars env, AbstractBuild<?, ?> build) {
-        if (FRAMEWORK_35.equals(framework) || FRAMEWORK_40.equals(framework) || FRAMEWORK_45.equals(framework))
+        if (FRAMEWORK_35.equals(framework) || FRAMEWORK_40.equals(framework) || FRAMEWORK_45.equals(framework)) {
             return framework;
-        else if (FRAMEWORK_OTHER.equals(framework))
+        } else if (FRAMEWORK_OTHER.equals(framework)) {
             return replaceMacro(otherFramework, env, build);
-        else
+        } else {
             return null;
+        }
     }
 
     /**
@@ -428,24 +479,26 @@ public class VsTestBuilder extends Builder {
      * @return
      */
     private String getLoggerArgument(EnvVars env, AbstractBuild<?, ?> build) {
-        if (LOGGER_TRX.equals(logger))
+        if (LOGGER_TRX.equals(logger)) {
             return logger;
-        else if (LOGGER_OTHER.equals(logger))
+        } else if (LOGGER_OTHER.equals(logger)) {
             return replaceMacro(otherLogger, env, build);
-        else
+        } else {
             return null;
+        }
     }
 
     /**
      * @param base
      * @param path
-     * @return the relative path of 'path'  
+     * @return the relative path of 'path'
      * @throws InterruptedException
-     * @throws IOException 
+     * @throws IOException
      */
     private String relativize(FilePath base, String path) throws InterruptedException, IOException {
         return base.toURI().relativize(new java.io.File(path).toURI()).getPath();
     }
+
     /**
      *
      * @param args
@@ -479,14 +532,15 @@ public class VsTestBuilder extends Builder {
 
             String trxPathRelativeToWorkspace = relativize(build.getWorkspace(), parserListener.getTrxFile());
             String coveragePathRelativeToWorkspace = relativize(build.getWorkspace(), parserListener.getCoverageFile());
-            
+
             build.addAction(new AddVsTestEnvVarsAction(trxPathRelativeToWorkspace, coveragePathRelativeToWorkspace));
 
-            if (failBuild)
+            if (failBuild) {
                 return (r == 0);
-            else {
-                if (r != 0)
+            } else {
+                if (r != 0) {
                     build.setResult(Result.UNSTABLE);
+                }
                 return true;
             }
         } catch (IOException e) {
@@ -495,7 +549,9 @@ public class VsTestBuilder extends Builder {
             return false;
         } finally {
             try {
-                if (tmpDir != null) tmpDir.delete();
+                if (tmpDir != null) {
+                    tmpDir.delete();
+                }
             } catch (IOException e) {
                 Util.displayIOException(e, listener);
                 e.printStackTrace(listener.fatalError("temporary file delete failed"));
@@ -540,7 +596,9 @@ public class VsTestBuilder extends Builder {
     private String concatString(List<String> args) {
         StringBuilder buf = new StringBuilder();
         for (String arg : args) {
-            if(buf.length() > 0)  buf.append(' ');
+            if (buf.length() > 0) {
+                buf.append(' ');
+            }
             buf.append(arg);
         }
         return buf.toString();
@@ -560,13 +618,11 @@ public class VsTestBuilder extends Builder {
         }
 
         public void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
-            if (trxEnv != null)
-            {
+            if (trxEnv != null) {
                 env.put(TRX_ENV, trxEnv);
             }
 
-            if (coverageEnv != null)
-            {
+            if (coverageEnv != null) {
                 env.put(COVERAGE_ENV, coverageEnv);
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -430,19 +430,13 @@ public class VsTestBuilder extends Builder {
     }
 
     private String[] expandFileSet(AbstractBuild<?, ?> build, String pattern) {
-        String[] result = new String[]{pattern};
-        FileSet fileSet = new FileSet();
-        org.apache.tools.ant.Project project = new org.apache.tools.ant.Project();
-        fileSet.setProject(project);
+        List<String> fileNames = new ArrayList<String>();
         try {
-            fileSet.setDir(new File(build.getWorkspace().toURI().getPath()));
-            fileSet.setIncludes(pattern);
-        } catch (IOException ioe) {
-            return result;
-        } catch (InterruptedException intE) {
-            return result;
-        }
-        return fileSet.getDirectoryScanner(project).getIncludedFiles();
+        for (FilePath x: build.getWorkspace().list(pattern))
+            fileNames.add(x.getRemote());
+        } catch (IOException ioe) {}
+        catch (InterruptedException inte) {}
+        return fileNames.toArray(new String[fileNames.size()]);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -421,7 +421,7 @@ public class VsTestBuilder extends Builder {
             if (!StringUtils.isBlank(testFile)) {
 
                 for (String file : expandFileSet(build, testFile)) {
-                    args.add(appendQuote(testFile));
+                    args.add(appendQuote(file));
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -21,11 +21,8 @@ import hudson.tasks.Builder;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.util.ArgumentListBuilder;
-import java.io.File;
-import java.nio.file.Paths;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.tools.ant.types.FileSet;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,3 @@
 <div>
-    This plugin run 'VSTest.Console.exe' command line tool to execute unit tests for .NET projects.
+    This plugin runs 'VSTest.Console.exe' command line tool to execute unit tests for .NET projects.
 </div>

--- a/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 BELLINSALARIN.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.vstest_runner;
+
+import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import static org.junit.Assert.assertTrue;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+
+/**
+ *
+ * @author BELLINSALARIN
+ */
+public class FileSetTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testResolveFileSet_noMatch() throws InterruptedException, IOException, Exception {
+
+        FreeStyleProject project = j.createFreeStyleProject();
+        VsTestBuilder builder = new VsTestBuilder("default", "**\\*.Tests", "", "", "", true, true, false, "", "", "", "", "trx", "", "", true);
+        project.getBuildersList().add(builder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        //build.getBuildStatusSummary().message;
+        assertTrue(build.getResult() == Result.FAILURE);
+        String s = FileUtils.readFileToString(build.getLogFile());
+        assertTrue(s.contains("no file matches the pattern **\\*.Tests"));
+        //String content = build.getWorkspace().child("AssemblyVersion.cs").readToString();
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
@@ -70,6 +70,7 @@ public class FileSetTest {
         project.getBuildersList().add(new TestBuilder() {
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
                 build.getWorkspace().child("aaa\\aaa.Tests.dll").write("La donna è mobile, qual più mal vento", "UTF-8");
+                build.getWorkspace().child("vstest.console.exe").chmod(700);
                 return true;
             }
         });
@@ -80,5 +81,6 @@ public class FileSetTest {
         String s = FileUtils.readFileToString(build.getLogFile());
         //assertTrue(s.contains("no file matches the pattern **\\*.Tests.dll"));
         //String content = build.getWorkspace().child("AssemblyVersion.cs").readToString();
+        assertTrue(s.contains("aaa/aaa.Tests.dll"));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
@@ -61,4 +61,24 @@ public class FileSetTest {
         assertTrue(s.contains("no file matches the pattern **\\*.Tests"));
         //String content = build.getWorkspace().child("AssemblyVersion.cs").readToString();
     }
+
+    @Test
+    public void testResolveFileSet_someMatch() throws InterruptedException, IOException, Exception {
+
+        FreeStyleProject project = j.createFreeStyleProject();
+        VsTestBuilder builder = new VsTestBuilder("default", "**\\*.Tests.dll", "", "", "", true, true, false, "", "", "", "", "trx", "", "", true);
+        project.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                build.getWorkspace().child("aaa\\aaa.Tests.dll").write("La donna è mobile, qual più mal vento", "UTF-8");
+                return true;
+            }
+        });
+        project.getBuildersList().add(builder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        //build.getBuildStatusSummary().message;
+        assertTrue(build.getResult() == Result.FAILURE);
+        String s = FileUtils.readFileToString(build.getLogFile());
+        //assertTrue(s.contains("no file matches the pattern **\\*.Tests.dll"));
+        //String content = build.getWorkspace().child("AssemblyVersion.cs").readToString();
+    }
 }


### PR DESCRIPTION
Let the user specify an Ant fileset to match target assemblies to test. This enables the user to find the assemblies to test in the whole workspace. (Sometimes, the build configuration is "Release", other times it's "Debug").

Make paths exposed by environment variables (VSTEST_RESULT_TRX, VSTEST_RESULT_COVERAGE) relative to the workspace. This allows the user to use these environment variables in further publication steps (like the "Archive Artifact" publisher). This is a breaking change: in order to preserve the current behavior, the job owner shall specify a path like $WORKSPACE/$VSTEST_RESULT_TRX or $WORKSPACE/$VSTEST_RESULT_COVERAGE.