### PR TITLE
minor improvements

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -439,24 +439,16 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
             testFile = replaceMacro(testFile, env);
 
             if (!StringUtils.isBlank(testFile)) {
-
-                for (String file : expandFileSet(workspace, testFile)) {
-                    args.add(appendQuote(file));
+                try {
+                    for (FilePath filePath : workspace.list(testFile)) {
+                        args.add(appendQuote(relativize(workspace, filePath.getRemote())));
+                    }
+                } catch (IOException ignored) {
                 }
             }
         }
 
         return args;
-    }
-
-    private String[] expandFileSet(FilePath workspace, String pattern) throws InterruptedException {
-        List<String> fileNames = new ArrayList<>();
-        try {
-            for (FilePath x : workspace.list(pattern))
-                fileNames.add(x.getRemote());
-        } catch (IOException ioe) {
-        }
-        return fileNames.toArray(new String[fileNames.size()]);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -316,6 +316,7 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
             if (targets.size() == 0) {
                 listener.getLogger().println("no files matching the pattern " + this.testFiles);
                 if (this.failBuild) {
+                    run.setResult(Result.FAILURE);
                     throw new AbortException("no files matching the pattern " + this.testFiles);
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -3,7 +3,9 @@ package org.jenkinsci.plugins.vstest_runner;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.StringTokenizer;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -431,7 +433,7 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
      * @throws IOException
      */
     /* package */ List<String> getTestFilesArguments(FilePath workspace, EnvVars env) throws InterruptedException {
-        ArrayList<String> args = new ArrayList<>();
+        Set<String> files = new HashSet<>();
 
         StringTokenizer testFilesTokenizer = new StringTokenizer(testFiles, " \t\r\n");
 
@@ -442,14 +444,14 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
             if (!StringUtils.isBlank(testFile)) {
                 try {
                     for (FilePath filePath : workspace.list(testFile)) {
-                        args.add(appendQuote(relativize(workspace, filePath.getRemote())));
+                        files.add(appendQuote(relativize(workspace, filePath.getRemote())));
                     }
                 } catch (IOException ignored) {
                 }
             }
         }
 
-        return args;
+        return new ArrayList<>(files);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -600,7 +600,7 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
         Computer computer = workspace.toComputer();
         Node node = null;
         if (computer != null) node = computer.getNode();
-        return node != null ? Jenkins.getInstance() : node;
+        return node != null ? node : Jenkins.getInstance();
     }
 
     private static class AddVsTestEnvVarsAction implements EnvironmentContributingAction {

--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -430,8 +430,8 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
      * @throws InterruptedException
      * @throws IOException
      */
-    private List<String> getTestFilesArguments(FilePath workspace, EnvVars env) throws InterruptedException {
-        ArrayList<String> args = new ArrayList<String>();
+    /* package */ List<String> getTestFilesArguments(FilePath workspace, EnvVars env) throws InterruptedException {
+        ArrayList<String> args = new ArrayList<>();
 
         StringTokenizer testFilesTokenizer = new StringTokenizer(testFiles, " \t\r\n");
 
@@ -484,7 +484,7 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
      * @throws InterruptedException
      * @throws IOException
      */
-    private String relativize(FilePath base, String path) throws InterruptedException, IOException {
+    /* package */ String relativize(FilePath base, String path) throws InterruptedException, IOException {
         return base.toURI().relativize(new java.io.File(path).toURI()).getPath();
     }
 

--- a/src/test/java/org/jenkinsci/plugins/vstest_runner/FilePatternTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vstest_runner/FilePatternTest.java
@@ -61,7 +61,7 @@ public class FilePatternTest {
 
     @Test
     public void testGetTestFilesArguments() throws Exception {
-        createFile(subfolder, "testfile1.trx");
+        createFile(subfolder, "testfile 1.trx");
         createFile(subfolder, "testfile2.trx");
         createFile(subfolder, "testfile3.trx");
 
@@ -70,6 +70,17 @@ public class FilePatternTest {
         EnvVars envVars = new EnvVars();
         List<String> testFilesArguments = step.getTestFilesArguments(workspace, envVars);
         assertThat(testFilesArguments.size(), is(3));
+    }
+
+    @Test
+    public void testGetFilesArguments_WithNewLine() throws Exception {
+        createFile(subfolder, "testfile1.trx");
+        createFile(subfolder, "testfile 2.trx");
+        VsTestBuilder step = new VsTestBuilder();
+        step.setTestFiles("**/testfile1.trx\n**/testfile 2.trx\n**/*.trx");
+        EnvVars envVars = new EnvVars();
+        List<String> testFilesArguments = step.getTestFilesArguments(workspace, envVars);
+        assertThat(testFilesArguments.size(), is(2));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/vstest_runner/FilePatternTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vstest_runner/FilePatternTest.java
@@ -1,0 +1,85 @@
+package org.jenkinsci.plugins.vstest_runner;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Util;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class FilePatternTest {
+
+    private FilePath workspace;
+    private File subfolder;
+
+    @Before
+    public void setUp() throws Exception {
+        File parent = Util.createTempDir();
+        workspace = new FilePath(parent);
+        if (workspace.exists()) {
+            workspace.deleteRecursive();
+        }
+        workspace.mkdirs();
+        subfolder = new File(parent, "subfolder");
+        if (subfolder.exists()) {
+            boolean delete = subfolder.delete();
+            assertThat(delete, is(true));
+        }
+        boolean mkdirs = subfolder.mkdirs();
+        assertThat(mkdirs, is(true));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        workspace.deleteRecursive();
+    }
+
+    private String createFile(File folder, String child) throws Exception {
+        File file = new File(folder, child);
+        boolean newFile = file.createNewFile();
+        assertThat(newFile, is(true));
+        return file.getAbsolutePath();
+    }
+
+    @Test
+    public void testGetTestFilesArgument() throws Exception {
+        String absolutePath = createFile(subfolder, "testfile.trx");
+        VsTestBuilder step = new VsTestBuilder();
+        step.setTestFiles("**/*.trx");
+        EnvVars envVars = new EnvVars();
+        List<String> testFilesArguments = step.getTestFilesArguments(workspace, envVars);
+        assertThat(testFilesArguments.size(), is(1));
+        String path = testFilesArguments.get(0);
+        assertThat(path, is(step.relativize(workspace, absolutePath)));
+    }
+
+    @Test
+    public void testGetTestFilesArguments() throws Exception {
+        createFile(subfolder, "testfile1.trx");
+        createFile(subfolder, "testfile2.trx");
+        createFile(subfolder, "testfile3.trx");
+
+        VsTestBuilder step = new VsTestBuilder();
+        step.setTestFiles("**/*.trx");
+        EnvVars envVars = new EnvVars();
+        List<String> testFilesArguments = step.getTestFilesArguments(workspace, envVars);
+        assertThat(testFilesArguments.size(), is(3));
+    }
+
+    @Test
+    public void testRelativePath() throws Exception {
+        String absolutePath = createFile(subfolder, "testfile1.trx");
+        VsTestBuilder step = new VsTestBuilder();
+        String relativePath = step.relativize(workspace, absolutePath);
+        step.setTestFiles(relativePath);
+        EnvVars envVars = new EnvVars();
+        List<String> testFilesArguments = step.getTestFilesArguments(workspace, envVars);
+        assertThat(testFilesArguments.size(), is(1));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.vstest_runner;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.Cause;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
@@ -65,7 +66,7 @@ public class FileSetTest {
         builder.setCmdLineArgs("");
         builder.setFailBuild(true);
         project.getBuildersList().add(builder);
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
         j.assertBuildStatus(Result.FAILURE, build);
         j.assertLogContains("no files matching the pattern **\\*.Tests", build);
     }
@@ -79,7 +80,7 @@ public class FileSetTest {
         builder.setTestFiles("**\\*.Tests.dll");
         builder.setSettings("");
         builder.setTests("");
-        builder.setTestCaseFilter("");
+        builder.setTestCaseFilter("Priority=1|TestCategory=Odd Nightly");
         builder.setEnablecodecoverage(true);
         builder.setInIsolation(true);
         builder.setUseVsixExtensions(false);
@@ -98,8 +99,9 @@ public class FileSetTest {
 
         });
         project.getBuildersList().add(builder);
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
         j.assertBuildStatus(Result.FAILURE, build);
+        j.assertLogContains("/TestCaseFilter:\"Priority=1|TestCategory=Odd Nightly\"", build);
         j.assertLogContains("aaa/aaa.Tests.dll", build);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
@@ -101,6 +101,6 @@ public class FileSetTest {
         project.getBuildersList().add(builder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         j.assertBuildStatus(Result.FAILURE, build);
-        j.assertLogContains("aaa" + File.separator + "aaa.Tests.dll", build);
+        j.assertLogContains("aaa/aaa.Tests.dll", build);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vstest_runner/FileSetTest.java
@@ -30,7 +30,6 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.junit.Rule;


### PR DESCRIPTION
The relative path for each file makes it a lot more readable 👍 

This
```
vstest.console.exe "Geo.Test/bin/Release/Geo.Tests.dll" /Enablecodecoverage /InIsolation /UseVsixExtensions:false /Logger:trx
```
Instead of
```
vstest.console.exe "\agent\workspace\Geo_jenkins_FileTest-FYKINI5PJYS6AFX6RLATSSYQBERM6QLCVGXE3YFE2EOV5IRDBRHA\Geo.Test\bin\Release\Geo.Tests.dll" /Enablecodecoverage /UseVsixExtensions:false /Logger:trx
```

relativize also converts backslashes to forward slashes