### PR TITLE
Fixed bug where Windows slave paths would be prefixed with / by Linux master

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.net.URI;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
@@ -487,7 +488,14 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
      * @throws IOException
      */
     /* package */ String relativize(FilePath base, String path) throws InterruptedException, IOException {
-        return base.toURI().relativize(new java.io.File(path).toURI()).getPath();
+	try {
+		String urlencoded =  path.replace('\\', '/').replace(" ", "%20") ;
+		URI pathUri = new URI("file:///" + urlencoded);
+		return base.toURI().relativize(pathUri).getPath();
+	} catch(java.net.URISyntaxException e)
+	{
+		throw new IOException(e.toString());
+	}
     }
 
     /**


### PR DESCRIPTION
This caused the vstestrunner not be able to find the test DLLs.

I don't see a way to write a unit test for this that will run under Linux, since relativize uses a FilePath, that can only be initialized locally (which was the cause of the problem in the first place).