### PR TITLE
Relativize against uri

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -444,7 +444,7 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
             if (!StringUtils.isBlank(testFile)) {
                 try {
                     for (FilePath filePath : workspace.list(testFile)) {
-                        files.add(appendQuote(relativize(workspace, filePath.getRemote())));
+                        files.add(appendQuote(relativize(workspace, filePath)));
                     }
                 } catch (IOException ignored) {
                 }
@@ -486,8 +486,8 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
      * @throws InterruptedException
      * @throws IOException
      */
-    /* package */ String relativize(FilePath base, String path) throws InterruptedException, IOException {
-        return base.toURI().relativize(new java.io.File(path).toURI()).getPath();
+    /* package */ String relativize(FilePath base, FilePath path) throws InterruptedException, IOException {
+        return base.toURI().relativize(path.toURI()).getPath();
     }
 
     /**
@@ -526,10 +526,10 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
             String coveragePathRelativeToWorkspace = null;
 
             if (trxFullPath != null) {
-                trxPathRelativeToWorkspace = relativize(workspace, trxFullPath);
+                trxPathRelativeToWorkspace = relativize(workspace, workspace.child(trxFullPath));
             }
             if (coverageFullPath != null) {
-                coveragePathRelativeToWorkspace = relativize(workspace, parserListener.getCoverageFile());
+                coveragePathRelativeToWorkspace = relativize(workspace, workspace.child(parserListener.getCoverageFile()));
             }
 
             run.addAction(new AddVsTestEnvVarsAction(trxPathRelativeToWorkspace, coveragePathRelativeToWorkspace));

--- a/src/test/java/org/jenkinsci/plugins/vstest_runner/FilePatternTest.java
+++ b/src/test/java/org/jenkinsci/plugins/vstest_runner/FilePatternTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.is;
 public class FilePatternTest {
 
     private FilePath workspace;
-    private File subfolder;
+    private FilePath subfolder;
 
     @Before
     public void setUp() throws Exception {
@@ -27,13 +27,12 @@ public class FilePatternTest {
             workspace.deleteRecursive();
         }
         workspace.mkdirs();
-        subfolder = new File(parent, "subfolder");
+        subfolder = workspace.child("subfolder");
         if (subfolder.exists()) {
             boolean delete = subfolder.delete();
             assertThat(delete, is(true));
         }
-        boolean mkdirs = subfolder.mkdirs();
-        assertThat(mkdirs, is(true));
+        subfolder.mkdirs();
     }
 
     @After
@@ -41,16 +40,18 @@ public class FilePatternTest {
         workspace.deleteRecursive();
     }
 
-    private String createFile(File folder, String child) throws Exception {
-        File file = new File(folder, child);
-        boolean newFile = file.createNewFile();
-        assertThat(newFile, is(true));
-        return file.getAbsolutePath();
+    private FilePath createFile(FilePath folder, String child) throws Exception {
+        FilePath file = new FilePath(folder, child);
+        File newFile = new File(file.getRemote());
+        boolean createdNewFile = newFile.createNewFile();
+        assertThat(createdNewFile, is(true));
+        assertThat(file.exists(), is(true));
+        return file;
     }
 
     @Test
     public void testGetTestFilesArgument() throws Exception {
-        String absolutePath = createFile(subfolder, "testfile.trx");
+        FilePath absolutePath = createFile(subfolder, "testfile.trx");
         VsTestBuilder step = new VsTestBuilder();
         step.setTestFiles("**/*.trx");
         EnvVars envVars = new EnvVars();
@@ -87,7 +88,7 @@ public class FilePatternTest {
 
     @Test
     public void testRelativePath() throws Exception {
-        String absolutePath = createFile(subfolder, "testfile1.trx");
+        FilePath absolutePath = createFile(subfolder, "testfile1.trx");
         VsTestBuilder step = new VsTestBuilder();
         String relativePath = step.relativize(workspace, absolutePath);
         step.setTestFiles(relativePath);


### PR DESCRIPTION
I was prevented from creating a clean commit so I had to open #16 
Will rebase after #16 is merged

Here is the diff after the normalized line endings: https://github.com/jenkinsci/vstestrunner-plugin/pull/17/commits/9eada2ece5ee07c689ab92813652da390cb3ada8

When master is linux based `getRemote` returns invalid path for windows agents so use URI

```
C:\agent\workspace\rvices_features_jenkinsfile-2PMDL3E5ZGFEJLZMDZJ7N7GC2RLU2YYAAPBPOX34TO6VE2PWGRJQ>vstest.console 
"/\agent\workspace\rvices_features_jenkinsfile-2PMDL3E5ZGFEJLZMDZJ7N7GC2RLU2YYAAPBPOX34TO6VE2PWGRJQ\UnitTests\WSITest\bin\Release\SomeTest.dll"
/Enablecodecoverage /UseVsixExtensions:false /Logger:trx
```