### PR TITLE
vstestrunner-plugin follow/guarantees the order of defined test files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vstest_runner/VsTestBuilder.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.vstest_runner;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -432,7 +432,7 @@ public class VsTestBuilder extends Builder implements SimpleBuildStep {
      * @throws IOException
      */
     /* package */ List<String> getTestFilesArguments(FilePath workspace, EnvVars env) throws InterruptedException {
-        Set<String> files = new HashSet<>();
+        Set<String> files = new LinkedHashSet<>();
 
         StringTokenizer testFilesTokenizer = new StringTokenizer(testFiles, " \t\r\n");
 


### PR DESCRIPTION
Replaced HashSet with LinkedHashSet which maintains insertion order.

----
Before this fix, vstestrunner-plugin did not follow/guaranteed the order of defined test files.

For example if we defined "Test Files" as:
```
A.Tests.dll
B.Tests.dll
C.Tests.dll
```

then one of possible outcomes could be that vstestrunner-plugin called "vstest" with test file arguments like
`vstest.console.exe "C.Tests.dll" "A.Tests.dll" "B.Tests.dll" /logger:trx`

what is not the order we defined.
