### PR TITLE
Add an option to skip running tests if no test files are found

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/vstest_runner/VsTestBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vstest_runner/VsTestBuilder/config.jelly
@@ -62,6 +62,10 @@
             <f:checkbox default="${descriptor.defaultFailBuild}"/>
         </f:entry>
 
+        <f:entry title="${%Skip if no tests}" field="skipIfNoTests">
+            <f:checkbox default="${descriptor.defaultSkipIfNoTests}"/>
+        </f:entry>
+
     </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vstest_runner/VsTestBuilder/help-skipIfNoTests.html
+++ b/src/main/resources/org/jenkinsci/plugins/vstest_runner/VsTestBuilder/help-skipIfNoTests.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        If this is checked and no test files are found the test execution will be skipped.
+    </p>
+</div>


### PR DESCRIPTION
A new job configuration checkbox called "Skip if no tests" has been added. It defaults to unchecked to preserve the previous current behavior. If this checkbox is checked the build will result in success if no test files are found. Without this patch a project without test files would result in an unstable build.

### Testing done

We have tried building projects with and without test files, both with and without the new configuration, to make sure that the default behavior is preserved. Testing was done with configuration in the UI for a normal Jenkins job and using a pipeline job. We did not added automated tests.

https://issues.jenkins.io/browse/JENKINS-72247

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```